### PR TITLE
Fix overwriting globalThis.daggerheart

### DIFF
--- a/module/simple.js
+++ b/module/simple.js
@@ -157,9 +157,7 @@ Hooks.once("init", async function () {
     EntitySheetHelper: EntitySheetHelper
   };
 
-  globalThis.daggerheart = {
-    EntitySheetHelper
-  };
+  globalThis.daggerheart.EntitySheetHelper = EntitySheetHelper;
 
   CONFIG.Actor.documentClass = SimpleActor;
   CONFIG.Actor.typeLabels = {


### PR DESCRIPTION
Fix problem with setting globalThis.daggerheart.EntitySheetHelper mentioned in issue #59 

This doesn't actually handle the main request of the issue (to allow dragging weapon to macro bar)