### PR TITLE
Fix bug with localization

### DIFF
--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -32,7 +32,7 @@
                 <!-- resources and fields -->
                 <div class="header-top-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{data.name}}" placeholder="{{localize " DH.Name"}}" />
+                        <input name="name" type="text" value="{{data.name}}" placeholder="{{localize "DH.Name"}}" />
                     </h1>
                     <div class="header-domain">
                         <input type="text" name="system.chosenDomains.domain-one"
@@ -342,7 +342,7 @@
                         </div>
                         <div class="experience-row-column-2">
                             <input class="click-rollable-name" name="system.experience.1Name" type="text"
-                                value="{{systemData.experience.1Name}}" placeholder="{{localize " DH.Experience"}}" />
+                                value="{{systemData.experience.1Name}}" placeholder="{{localize "DH.Experience"}}" />
                         </div>
                         <div class="experience-row-column">
                             <input class="click-rollable-modifier" type="number" name="system.experience.1Mod"
@@ -357,7 +357,7 @@
                         </div>
                         <div class="experience-row-column-2">
                             <input class="click-rollable-name" name="system.experience.2Name" type="text"
-                                value="{{systemData.experience.2Name}}" placeholder="{{localize " DH.Experience"}}" />
+                                value="{{systemData.experience.2Name}}" placeholder="{{localize "DH.Experience"}}" />
                         </div>
                         <div class="experience-row-column">
                             <input class="click-rollable-modifier" type="number" name="system.experience.2Mod"
@@ -372,7 +372,7 @@
                         </div>
                         <div class="experience-row-column-2">
                             <input class="click-rollable-name" name="system.experience.5Name" type="text"
-                                value="{{systemData.experience.5Name}}" placeholder="{{localize " DH.Experience"}}" />
+                                value="{{systemData.experience.5Name}}" placeholder="{{localize "DH.Experience"}}" />
                         </div>
                         <div class="experience-row-column">
                             <input class="click-rollable-modifier" type="number" name="system.experience.5Mod"
@@ -387,7 +387,7 @@
                         </div>
                         <div class="experience-row-column-2">
                             <input class="click-rollable-name" name="system.experience.8Name" type="text"
-                                value="{{systemData.experience.8Name}}" placeholder="{{localize " DH.Experience"}}" />
+                                value="{{systemData.experience.8Name}}" placeholder="{{localize "DH.Experience"}}" />
                         </div>
                         <div class="experience-row-column">
                             <input class="click-rollable-modifier" type="number" name="system.experience.8Mod"
@@ -402,7 +402,7 @@
                         </div>
                         <div class="experience-row-column-2">
                             <input class="click-rollable-name" name="system.experience.1Name2" type="text"
-                                value="{{systemData.experience.1Name2}}" placeholder="{{localize " DH.Experience"}}" />
+                                value="{{systemData.experience.1Name2}}" placeholder="{{localize "DH.Experience"}}" />
                         </div>
                         <div class="experience-row-column">
                             <input class="click-rollable-modifier" type="number" name="system.experience.1Mod2"
@@ -459,11 +459,10 @@
                                     <input
                                         class="weapon-field basic-rollable-name click-rollable-name {{#if weaponDisplay.primary.hasWeapon}}weapon-field-hidden{{/if}}"
                                         name="system.weapon-main.name" type="text"
-                                        value="{{systemData.weapon-main.name}}" placeholder="{{localize "
-                                        DH.Weapon"}}" />
+                                        value="{{systemData.weapon-main.name}}" placeholder="{{localize "DH.Weapon"}}" />
                                     <div class="textarea-container">
                                         <input class="trait-effects resize-ta" name="system.weapon-main.description"
-                                            placeholder="{{localize " DH.WeaponTraitsHere"}}"
+                                            placeholder="{{localize "DH.WeaponTraitsHere"}}"
                                             value="{{systemData.weapon-main.description}}" />
                                     </div>
                                 </div>
@@ -474,8 +473,7 @@
                                             data-has-modifiers="true">{{#if
                                             systemData.weapon-main.to-hit.value}}{{systemData.weapon-main.to-hit.value}}{{else}}0{{/if}}
                                         </div>
-                                        <a class="trait-effects click-rollable" data-roll-type="attack">{{localize
-                                            "DH.Modifier"}}</a>
+                                        <a class="trait-effects click-rollable" data-roll-type="attack">{{localize "DH.Modifier"}}</a>
                                     </div>
                                     <div class="weapon-infobox">
                                         <div class="weapon-damage-display damage-value-display {{#if weaponDisplay.primary.hasWeapon}}primary-weapon{{/if}}"
@@ -487,8 +485,7 @@
                                             {{this.value}}{{/if}}{{/each}}{{/if}}{{else}}{{#if
                                             systemData.weapon-main.damage}}{{systemData.weapon-main.damage}}{{else}}1d8{{/if}}{{/if}}
                                         </div>
-                                        <a class="trait-effects basic-rollable" data-roll-type="damage">{{localize
-                                            "DH.Damage"}}</a>
+                                        <a class="trait-effects basic-rollable" data-roll-type="damage">{{localize "DH.Damage"}}</a>
                                     </div>
                                 </div>
                             </div>
@@ -508,10 +505,10 @@
                                     <input
                                         class="weapon-field basic-rollable-name click-rollable-name {{#if weaponDisplay.secondary.hasWeapon}}weapon-field-hidden{{/if}}"
                                         name="system.weapon-off.name" type="text" value="{{systemData.weapon-off.name}}"
-                                        placeholder="{{localize " DH.Weapon"}}" />
+                                        placeholder="{{localize "DH.Weapon"}}" />
                                     <div class="textarea-container">
                                         <input class="trait-effects resize-ta" name="system.weapon-off.description"
-                                            placeholder="{{localize " DH.WeaponTraitsHere"}}"
+                                            placeholder="{{localize "DH.WeaponTraitsHere"}}"
                                             value="{{systemData.weapon-off.description}}" />
                                     </div>
                                 </div>
@@ -1087,7 +1084,7 @@
                         <a class="item-control" title="{{ localize 'SIMPLE.ItemCreate' }}" data-action="create-item"
                             data-type="item" data-location="vault">
                             <i class="fas fa-plus"></i></a>
-                        <a class="item-control vault-toggle" title="{{localize " DH.ToggleVault"}}"><i
+                        <a class="item-control vault-toggle" title="{{localize "DH.ToggleVault"}}"><i
                                 class="fas fa-chevron-down"></i></a>
                     </div>
                 </div>


### PR DESCRIPTION
Remove white space from placeholders to make localization strings work correctly.

Before:
<img width="419" height="57" alt="image" src="https://github.com/user-attachments/assets/7074b49e-6733-4391-8841-c3d82f37d551" />
<img width="534" height="131" alt="image" src="https://github.com/user-attachments/assets/2a0810e5-aa02-4856-9278-5cb4b55b7dbc" />
After:
<img width="428" height="123" alt="image" src="https://github.com/user-attachments/assets/cf041881-d4a9-4f94-aacf-64bec040d19d" />
<img width="558" height="145" alt="image" src="https://github.com/user-attachments/assets/4d762d21-b846-4736-bb21-540148bb0a4b" />
