### PR TITLE
Advantage die setting

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,6 +3,8 @@
   "SETTINGS.SimpleMacroShorthandL": "Enable a shortened macro syntax which allows referencing attributes directly, for example @str instead of @attributes.str.value. Disable this setting if you need the ability to reference the full attribute model, for example @attributes.str.label.",
   "SETTINGS.SimpleInitFormulaN": "Initiative Formula",
   "SETTINGS.SimpleInitFormulaL": "Enter an initiative formula, such as d20+@dex",
+  "SETTINGS.AdvantageDieTypesN": "Advantage Die Types Shown",
+  "SETTINGS.AdvantageDieTypesL": "Enter die types to show in roll dialog for advantage/disadvantage. Choose any combination from d4, d6, d8, and d10. For example 'd6,d10'",
   "SIMPLE.ItemCreate": "Create Item",
   "SIMPLE.ItemEdit": "Edit Item",
   "SIMPLE.ItemDelete": "Delete Item",

--- a/module/dialog-helper.js
+++ b/module/dialog-helper.js
@@ -558,7 +558,7 @@ export class DaggerheartDialogHelper {
       }
     }
 
-    const allowedDice = (game.settings.get("daggerheart", "dualityDiceTypes") || "d6").split(",");
+    const allowedDice = (game.settings.get("daggerheart", "advantageDieTypes") || "d6").split(",");
     const diceControls = allowedDice.map(die => `
       <div class="dice-control" data-die="${die}">
         <button type="button" class="dice-btn increase" data-type="advantage" data-die="${die}"><i class="fas fa-plus"></i></button>

--- a/module/dialog-helper.js
+++ b/module/dialog-helper.js
@@ -558,6 +558,19 @@ export class DaggerheartDialogHelper {
       }
     }
 
+    const allowedDice = (game.settings.get("daggerheart", "dualityDiceTypes") || "d6").split(",");
+    const diceControls = allowedDice.map(die => `
+      <div class="dice-control" data-die="${die}">
+        <button type="button" class="dice-btn increase" data-type="advantage" data-die="${die}"><i class="fas fa-plus"></i></button>
+        <div class="dice-icon ${die}-icon">
+          <i class="fad fa-dice-${[die]}"></i>
+          <span class="dice-count">${initialValues.advantage[die] - initialValues.disadvantage[die]}</span>
+        </div>
+        <button type="button" class="dice-btn decrease" data-type="advantage" data-die="${die}"><i class="fas fa-minus"></i></button>
+        <input type="hidden" name="advantage-${die}" value="${initialValues.advantage[die] - initialValues.disadvantage[die]}">
+      </div>
+    `).join("");
+
     const content = `
     <form>
     <div class="flex-col" style="align-items: stretch; gap: 2rem">
@@ -588,42 +601,7 @@ export class DaggerheartDialogHelper {
       <div class="flex-col">
         <span class="label-bar">Advantage / Disadvantage</span>
         <div class="dice-grid advantage-disadvantage-grid">
-          <div class="dice-control" data-die="d4">
-            <button type="button" class="dice-btn increase" data-type="advantage" data-die="d4"><i class="fas fa-plus"></i></button>
-            <div class="dice-icon d4-icon">
-              <i class="fad fa-dice-d4"></i>
-              <span class="dice-count">${initialValues.advantage.d4 - initialValues.disadvantage.d4}</span>
-            </div>
-            <button type="button" class="dice-btn decrease" data-type="advantage" data-die="d4"><i class="fas fa-minus"></i></button>
-            <input type="hidden" name="advantage-d4" value="${initialValues.advantage.d4 - initialValues.disadvantage.d4}">
-          </div>
-          <div class="dice-control" data-die="d6">
-            <button type="button" class="dice-btn increase" data-type="advantage" data-die="d6"><i class="fas fa-plus"></i></button>
-            <div class="dice-icon d6-icon">
-              <i class="fad fa-dice-d6"></i>
-              <span class="dice-count">${initialValues.advantage.d6 - initialValues.disadvantage.d6}</span>
-            </div>
-            <button type="button" class="dice-btn decrease" data-type="advantage" data-die="d6"><i class="fas fa-minus"></i></button>
-            <input type="hidden" name="advantage-d6" value="${initialValues.advantage.d6 - initialValues.disadvantage.d6}">
-          </div>
-          <div class="dice-control" data-die="d8">
-            <button type="button" class="dice-btn increase" data-type="advantage" data-die="d8"><i class="fas fa-plus"></i></button>
-            <div class="dice-icon d8-icon">
-              <i class="fad fa-dice-d8"></i>
-              <span class="dice-count">${initialValues.advantage.d8 - initialValues.disadvantage.d8}</span>
-            </div>
-            <button type="button" class="dice-btn decrease" data-type="advantage" data-die="d8"><i class="fas fa-minus"></i></button>
-            <input type="hidden" name="advantage-d8" value="${initialValues.advantage.d8 - initialValues.disadvantage.d8}">
-          </div>
-          <div class="dice-control" data-die="d10">
-            <button type="button" class="dice-btn increase" data-type="advantage" data-die="d10"><i class="fas fa-plus"></i></button>
-            <div class="dice-icon d10-icon">
-              <i class="fad fa-dice-d10"></i>
-              <span class="dice-count">${initialValues.advantage.d10 - initialValues.disadvantage.d10}</span>
-            </div>
-            <button type="button" class="dice-btn decrease" data-type="advantage" data-die="d10"><i class="fas fa-minus"></i></button>
-            <input type="hidden" name="advantage-d10" value="${initialValues.advantage.d10 - initialValues.disadvantage.d10}">
-          </div>
+          ${diceControls}
         </div>
       </div>
       <div class="flex-row">

--- a/module/simple.js
+++ b/module/simple.js
@@ -253,6 +253,15 @@ Hooks.once("init", async function () {
     onChange: formula => _simpleUpdateInit(formula, true)
   });
 
+  game.settings.register("daggerheart", "dualityDiceTypes", {
+    name: "SETTINGS.AdvantageDieTypesN",
+    hint: "SETTINGS.AdvantageDieTypesL",
+    scope: "world",
+    config: true,
+    type: String,
+    default: "d4,d6,d8,d10",
+  });
+
   const initFormula = game.settings.get("daggerheart", "initFormula");
   _simpleUpdateInit(initFormula);
 

--- a/module/simple.js
+++ b/module/simple.js
@@ -253,7 +253,7 @@ Hooks.once("init", async function () {
     onChange: formula => _simpleUpdateInit(formula, true)
   });
 
-  game.settings.register("daggerheart", "dualityDiceTypes", {
+  game.settings.register("daggerheart", "advantageDieTypes", {
     name: "SETTINGS.AdvantageDieTypesN",
     hint: "SETTINGS.AdvantageDieTypesL",
     scope: "world",


### PR DESCRIPTION
Allow customizing the die types shown for advantage/disadvantage. Included setting strings  in localization file.

Context: My playgroup only wants to use d6, and people keep getting confused by the multiple die types shown for advantage. I defaulted the setting to show all the currently shown die types, but unwanted types can be removed.

<img width="531" height="91" alt="image" src="https://github.com/user-attachments/assets/1909680e-ed89-4319-9ceb-7f8373971b9a" />
<img width="236" height="208" alt="image" src="https://github.com/user-attachments/assets/ffbae6b8-2bd8-4909-8687-2ba4eeb2bc1c" />

