### PR TITLE
Fix: Only link player sheets

### DIFF
--- a/module/simple.js
+++ b/module/simple.js
@@ -1233,13 +1233,10 @@ Hooks.on("getSceneControlButtons", (controls) => {
 });
 
 Hooks.on("preCreateActor", function (document, data, options, userId) {
-
-  const prototypeToken = {
-    actorLink: true
-  };
-
   document.updateSource({
-    "prototypeToken": foundry.utils.mergeObject(document.prototypeToken?.toObject() || {}, prototypeToken)
+    "prototypeToken": foundry.utils.mergeObject(document.prototypeToken?.toObject() || {}, {
+      actorLink: data.type === 'character' || data.type === 'companion'
+    })
   });
 });
 


### PR DESCRIPTION
QOL: As a GM I rarely want my adversary sheets to be linked. Follows the standard of most other systems and only link player facing sheets by default.