### PR TITLE
Exempt 'mi' and 'km' scenes from narrative ruler

### DIFF
--- a/module/range-measurement.js
+++ b/module/range-measurement.js
@@ -96,7 +96,9 @@ export class DaggerheartMeasuredTemplate extends foundry.canvas.placeables.Measu
         const close = game.settings.get('daggerheart', 'rangeMeasurementClose');
         const far = game.settings.get('daggerheart', 'rangeMeasurementFar');
         const veryFar = game.settings.get('daggerheart', 'rangeMeasurementVeryFar');
-
+        if ((canvas.grid.units == 'mi' || canvas.grid.units == 'km')){
+            return ''
+        }
         if (distance <= melee) {
             return game.i18n.localize('DAGGERHEART.CONFIG.Range.melee.name');
         }

--- a/module/simple.js
+++ b/module/simple.js
@@ -274,7 +274,7 @@ Hooks.once("init", async function () {
   // Register range measurement settings
   game.settings.register("daggerheart", "rangeMeasurementEnabled", {
     name: "DAGGERHEART.SETTINGS.RangeMeasurement.enabled",
-    hint: "Enable narrative range measurement display",
+    hint: "Enable narrative range measurement display (scenes using 'mi' or 'km' as units are exempt)",
     scope: "world",
     config: true,
     type: Boolean,


### PR DESCRIPTION
Resolves #93 . Crude check that simply skips the narrative label for scenes with 'mi' or 'km' defined as the units.